### PR TITLE
Simplify IntelliJ gitignore

### DIFF
--- a/src/main/g8/.gitignore
+++ b/src/main/g8/.gitignore
@@ -256,34 +256,6 @@ cwallet.sso.lck# JEnv local Java version configuration file
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-# User-specific stuff
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
-
-# Sensitive or high-churn files
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
-
-# Gradle
-.idea/**/gradle.xml
-.idea/**/libraries
-
-# Gradle and Maven with auto-import
-# When using Gradle or Maven with auto-import, you should exclude module files,
-# since they will be recreated, and may cause churn.  Uncomment if using
-# auto-import.
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-
 # CMake
 cmake-build-*/
 
@@ -355,22 +327,7 @@ captures/
 
 # IntelliJ
 *.iml
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/gradle.xml
-.idea/assetWizardSettings.xml
-.idea/dictionaries
-.idea/libraries
-.idea/caches
-.idea/compiler.xml
-.idea/encodings.xml
-.idea/misc.xml
-.idea/modules.xml
-.idea/sbt.xml
-.idea/scala_compiler.xml
-.idea/codeStyles/codeStyleConfig.xml
-.idea/codeStyles/Project.xml
-.idea/hydra.xml
+.idea
 
 # Keystore files
 # Uncomment the following line if you do not want to check your keystore files in.


### PR DESCRIPTION
I think it's safe to simply ignore `.idea` rather than the long list that it currently is. I ran into this here:
https://github.com/zio/zio-process/pull/1

The current gitignore isn't catching files like `.idea/.name`, `.idea/scala_settings.xml`, etc. for me.